### PR TITLE
Add Dependbot updates for the Dockerfile

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+updates:
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "10:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "#patch"
+    pull-request-branch-name:
+      separator: "-"

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,8 +4,9 @@ WORKDIR /root
 
 RUN apt-get update
 RUN apt-get upgrade -y
-RUN npm install "cypress-grep"
-RUN npm install "cypress-failed-log"
+
+RUN npm install "cypress-grep@2.12.0"
+RUN npm install "cypress-failed-log@2.9.2"
 
 ENV CYPRESS_VIDEO=false
 


### PR DESCRIPTION
- Add Dependabot updates for the Dockerfile
- Pin cypress-grep to 2.12.0
- Pin cypress-failed-log to 2.9.2