### PR TITLE
SW-5434 - Run E2E Tests against local Sirius #minor"

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -87,7 +87,7 @@ jobs:
         uses: EnricoMi/publish-unit-test-result-action@v1
         if: always()
         with:
-          files: "artifacts/test-results/*.xml"
+          files: "artifacts/end-to-end-results/test-results/*.xml"
 
       - name: Push Container
         env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -35,7 +35,8 @@ jobs:
 
       - name: Build Container
         run: |
-          docker build --tag sirius/end-to-end-tests:latest -f Dockerfile .
+          make build
+
       - name: Scan
         run: |
           docker run --rm  -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy image sirius/end-to-end-tests:latest
@@ -66,6 +67,27 @@ jobs:
         uses: aws-actions/amazon-ecr-login@v1
         with:
           registries: 311462405659
+
+      - name: Run Tests against local Sirius
+        run: |
+          make unpack-sirius-components
+          make pull-sirius-containers
+          make start-sirius
+          make local-end-to-end-tests
+          make stop-sirius
+
+      - name: Upload Logs & Screenshots
+        uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: Test Logs & Screenshots
+          path: artifacts/end-to-end-results/
+
+      - name: Publish Unit Test Results
+        uses: EnricoMi/publish-unit-test-result-action@v1
+        if: always()
+        with:
+          files: "artifacts/test-results/*.xml"
 
       - name: Push Container
         env:

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 node_modules
 test-results/*.xml
+artifacts/

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,8 @@ scan:
 	trivy image sirius/end-to-end-tests:latest
 
 unpack-sirius-components:
-	docker image pull 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.2
-	docker run --rm -d -i --name build-artifacts 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.2
+	docker image pull 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:latest
+	docker run --rm -d -i --name build-artifacts 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:latest
 	docker cp build-artifacts:/artifacts .
 	docker kill build-artifacts
 

--- a/Makefile
+++ b/Makefile
@@ -14,10 +14,11 @@ unpack-sirius-components:
 	docker kill build-artifacts
 
 pull-sirius-containers:
-	cd artifacts && docker-compose pull --include-deps frontend-proxy
+	cd artifacts && docker-compose pull --quiet --include-deps frontend-proxy
 
 start-sirius:
 	cd artifacts && make import-fixtures
+	cd artifacts && docker-compose stop queue
 
 local-end-to-end-tests:
 	mkdir -p -m777 artifacts/end-to-end-results/logs

--- a/Makefile
+++ b/Makefile
@@ -4,5 +4,29 @@ export DOCKER_BUILDKIT ?= 1
 build:
 	docker-compose build cypress
 
+scan:
+	trivy image sirius/end-to-end-tests:latest
+
+unpack-sirius-components:
+	docker image pull 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.1
+	docker run --rm -d -i --name build-artifacts 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.1
+	docker cp build-artifacts:/artifacts .
+	docker stop build-artifacts
+
+pull-sirius-containers:
+	cd artifacts && docker-compose pull --include-deps frontend-proxy
+
+start-sirius:
+	cd artifacts && make import-fixtures
+
+local-end-to-end-tests:
+	mkdir -p -m777 artifacts/end-to-end-results/logs
+	mkdir -p -m777 artifacts/end-to-end-results/screenshots
+	mkdir -p -m777 artifacts/test-results
+	cd artifacts && END_TO_END_IMAGE=sirius/end-to-end-tests:latest docker-compose run end-to-end-tests
+
+stop-sirius:
+	cd artifacts && docker-compose down
+
 dev:
 	docker run --rm -e CYPRESS_BASE_URL="https://dev.sirius.opg.digital" sirius/end-to-end-tests:latest

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ scan:
 	trivy image sirius/end-to-end-tests:latest
 
 unpack-sirius-components:
-	docker image pull 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.1
-	docker run --rm -d -i --name build-artifacts 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.1
+	docker image pull 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.2
+	docker run --rm -d -i --name build-artifacts 311462405659.dkr.ecr.eu-west-1.amazonaws.com/sirius/build-artifacts:v6.77.0-SW-5434.2
 	docker cp build-artifacts:/artifacts .
-	docker stop build-artifacts
+	docker kill build-artifacts
 
 pull-sirius-containers:
 	cd artifacts && docker-compose pull --include-deps frontend-proxy
@@ -22,11 +22,13 @@ start-sirius:
 local-end-to-end-tests:
 	mkdir -p -m777 artifacts/end-to-end-results/logs
 	mkdir -p -m777 artifacts/end-to-end-results/screenshots
-	mkdir -p -m777 artifacts/test-results
+	mkdir -p -m777 artifacts/end-to-end-results/test-results
 	cd artifacts && END_TO_END_IMAGE=sirius/end-to-end-tests:latest docker-compose run end-to-end-tests
 
 stop-sirius:
 	cd artifacts && docker-compose down
+
+local-run: unpack-sirius-components pull-sirius-containers start-sirius local-end-to-end-tests stop-sirius
 
 dev:
 	docker run --rm -e CYPRESS_BASE_URL="https://dev.sirius.opg.digital" sirius/end-to-end-tests:latest


### PR DESCRIPTION
- SW-5434 - Pull Sirius build artifacts container and use to run tests against Sirius #minor
- SW-5434 - Move test-results dir #patch
