### PR TITLE
Force typing in potentially-covered field

### DIFF
--- a/cypress/integration/lpa/cases/epa.spec.js
+++ b/cypress/integration/lpa/cases/epa.spec.js
@@ -13,7 +13,7 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.get(".action-widget-content").within(() => {
       cy.get("#epaDonorSignatureDate0").type("21/09/2007");
-      cy.get("#epaDonorNoticeGivenDate0").type("21/09/2007");
+      cy.get("#epaDonorNoticeGivenDate0").type("21/09/2007", { force: true });
 
       cy.contains(
         "To your knowledge, has the donor made any other Enduring Powers of Attorney?"


### PR DESCRIPTION
When Andy runs this locally it complains that the `#epaDonorNoticeGivenDate0` is covered by the date picker from `#epaDonorSignatureDate0`. This is true, and a reasonable reason to use `{ force: true }`, though it's weird that it doesn't happen on other environments.

#patch