### PR TITLE
VEGA-1218 Requery for RetrieveDraft button

### DIFF
--- a/cypress/integration/lpa/cases/documents.spec.js
+++ b/cypress/integration/lpa/cases/documents.spec.js
@@ -51,7 +51,8 @@ describe("Documents", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.wait(["@casesRequest", "@eventsRequest", "@draftCountRequest"]);
     cy.wait("@draftCountRequest");
 
-    cy.get("#RetrieveDraft").not('have.class', 'disabled').click();
+    cy.get("#RetrieveDraft").not('have.class', 'disabled');
+    cy.get("#RetrieveDraft").click();
     cy.wait("@getDocumentRequest");
 
     cy.frameLoaded(".tox-edit-area__iframe");


### PR DESCRIPTION
Seems to still be failing, now with "`cy.click()` failed because this element is detached from the DOM". Hopefully by querying for the button again the problem will be solved...