### PR TITLE
Fix timeline event detection

### DIFF
--- a/cypress/.gitignore
+++ b/cypress/.gitignore
@@ -1,3 +1,4 @@
 logs
 screenshots
 videos
+.vscode

--- a/cypress/integration/lpa/donors/donor.spec.js
+++ b/cypress/integration/lpa/donors/donor.spec.js
@@ -47,7 +47,7 @@ describe("Edits a Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.wait('@personRequest');
 
-    cy.get('.timeline .timeline-event', { timeout: 10000 });
+    cy.get('.timeline-event').contains('Person (Create / Edit)', { timeout: 10000 });
     cy.get(".timeline-event").first().should("contain", "First name: Bob changed to: Patrick");
   });
 });


### PR DESCRIPTION
Fix a test step that always passes because there are already timeline events that match. Make it look for the timeline event with the create/edit in it.