### PR TITLE
sw-5440: Edit client test fix

### DIFF
--- a/cypress/integration/supervision/clients/edit-client.spec.js
+++ b/cypress/integration/supervision/clients/edit-client.spec.js
@@ -1,34 +1,33 @@
-// TODO - This passes locally, but getting input[name="firstName"] is regularly failing in CI due to
-//  Angular re-rendering the element. As the feedback loop is currently nearly 30 minutes I'm pausing investigation
-//  until the test running for this repository is completed
+ beforeEach(() => {
+  cy.loginAs('Case Manager');
+  cy.createAClient();
+});
 
-// beforeEach(() => {
-//   cy.loginAs('Case Manager');
-//   cy.createAClient();
-// });
-//
-// describe('Edit a client', { tags: ['@supervision', 'client', '@smoke-journey'] }, () => {
-//   it(
-//     'Given I\'m a Case Manager on Supervision and on the client dashboard page' +
-//     'Then the Client Dashboard page loads as expected',
-//     () => {
-//       cy.get('@clientId').then(clientId => {
-//         cy.visit('/supervision/#/clients/' + clientId + '/edit');
-//       });
-//       cy.contains('Edit Client: Ted Tedson');
-//
-//       const suffix = Math.floor(Math.random() * 10000);
-//
-//       cy.get('input[name="firstName"]', {timeout: 30000}).should('have.value', 'Ted').clear().type('Bill' + suffix);
-//       cy.get('input[name="lastName"]').clear().type('Billson' + suffix);
-//       cy.get('input[name="memorablePhrase"]').clear().type('Memorable' + suffix);
-//
-//       cy.contains('Save & Exit').click();
-//
-//       cy.contains('Client details');
-//       cy.contains('Bill' + suffix, {timeout: 30000});
-//       cy.contains('Billson' + suffix);
-//       cy.contains('Memorable' + suffix);
-//     }
-//   );
-// });
+describe('Edit a client', { tags: ['@supervision', 'client', '@smoke-journey'] }, () => {
+  it(
+    'Given I\'m a Case Manager on Supervision and on the client dashboard page' +
+    'Then the Client Dashboard page loads as expected',
+    () => {
+      cy.get('@clientId').then(clientId => {
+        cy.visit('/supervision/#/clients/' + clientId + '/edit');
+      });
+      cy.contains('Edit Client: Ted Tedson');
+
+      const suffix = Math.floor(Math.random() * 10000);
+
+      cy.get('#editClientFormContent').as('edit-panel');
+      cy.get('@edit-panel').within(() => {
+        cy.get('input[name="firstName"]').clear().type('Bill' + suffix);
+        cy.get('input[name="lastName"]').clear().type('Billson' + suffix);
+        cy.get('input[name="memorablePhrase"]').clear().type('Memorable' + suffix);
+      });
+
+      cy.contains('Save & Exit').click();
+
+      cy.contains('Client details');
+      cy.contains('Bill' + suffix, {timeout: 30000});
+      cy.contains('Billson' + suffix);
+      cy.contains('Memorable' + suffix);
+    }
+  );
+});

--- a/cypress/integration/supervision/clients/edit-client.spec.js
+++ b/cypress/integration/supervision/clients/edit-client.spec.js
@@ -9,25 +9,26 @@ describe('Edit a client', { tags: ['@supervision', 'client', '@smoke-journey'] }
     'Then the Client Dashboard page loads as expected',
     () => {
       cy.get('@clientId').then(clientId => {
-        cy.visit('/supervision/#/clients/' + clientId + '/edit');
+        cy.visit(`/supervision/#/clients/${clientId}/edit`);
       });
       cy.contains('Edit Client: Ted Tedson');
 
       const suffix = Math.floor(Math.random() * 10000);
+      const firstName = 'Bill' + suffix;
+      const lastName = 'Billson' + suffix;
+      const memorablePhrase = 'Memorable' + suffix
 
       cy.get('#editClientFormContent').as('edit-panel');
       cy.get('@edit-panel').within(() => {
-        cy.get('input[name="firstName"]').clear().type('Bill' + suffix);
-        cy.get('input[name="lastName"]').clear().type('Billson' + suffix);
-        cy.get('input[name="memorablePhrase"]').clear().type('Memorable' + suffix);
+        cy.get('input[name="firstName"]').clear().type(firstName);
+        cy.get('input[name="lastName"]').clear().type(lastName);
+        cy.get('input[name="memorablePhrase"]').clear().type(memorablePhrase);
+        cy.contains('Save & Exit').click();
       });
 
-      cy.contains('Save & Exit').click();
-
-      cy.contains('Client details');
-      cy.contains('Bill' + suffix, {timeout: 30000});
-      cy.contains('Billson' + suffix);
-      cy.contains('Memorable' + suffix);
+      cy.get('.right-side').contains('.sub-section-header', 'Client details');
+      cy.contains('.client-summary-full-name-value', `${firstName} ${lastName}`);
+      cy.contains('.client-summary-memorable-phrase-value', memorablePhrase);
     }
   );
 });

--- a/cypress/integration/supervision/dashboard/client-dashboard.spec.js
+++ b/cypress/integration/supervision/dashboard/client-dashboard.spec.js
@@ -3,17 +3,17 @@ beforeEach(() => {
   cy.createAClient();
 
   cy.get('@clientId').then(clientId => {
-    cy.visit('/supervision/#/clients/' + clientId);
+    cy.visit(`/supervision/#/clients/${clientId}`);
   });
 });
 
 describe('Viewing the client dashboard', { tags: ['@supervision', '@supervision-regression', '@client-dashboard'] }, () => {
   it('should load the client dashboard', () => {
-    cy.contains('.title-person-name', 'Ted Tedson', {timeout: 30000});
+    cy.contains('.title-person-name', 'Ted Tedson');
   });
 
-  // it('should navigate to the Edit Client page when the edit button is clicked', () => {
-  //   cy.contains('Edit client', {timeout: 30000}).should('be.visible').click();
-  //   cy.contains('Edit Client: Ted Tedson');
-  // });
+  it('should navigate to the Edit Client page when the edit button is clicked', () => {
+    cy.contains('#edit-client-button', 'Edit client').click();
+    cy.contains('Edit Client: Ted Tedson');
+  });
 });

--- a/cypress/integration/supervision/letters/create-letter.spec.js
+++ b/cypress/integration/supervision/letters/create-letter.spec.js
@@ -1,7 +1,7 @@
 const createOrder = () => {
   return cy.get('@clientId').then(clientId => {
     cy.fixture('order/minimal.json').then(order => {
-      cy.postToApi('/supervision-api/v1/clients/' + clientId + '/orders', order)
+      cy.postToApi(`/supervision-api/v1/clients/${clientId}/orders`, order)
         .its('body')
         .then(res => {
           cy.wrap(res.caseRecNumber).as('courtReference');
@@ -11,20 +11,12 @@ const createOrder = () => {
   });
 };
 
-const getIframeDocument = () => {
-  return cy.get('iframe[id="editor_ifr"]', {timeout:30000}).its('0.contentDocument').should('exist')
-}
-
 const getIframeBody = () => {
-  return getIframeDocument().its('body').should('not.be.undefined').then(cy.wrap)
-}
-
-const getRecipientHeader = () => {
-  return cy.get('.smart__action > ng-component:nth-child(2) > div:nth-child(1) > draft-select-recipients:nth-child(1) > div:nth-child(1) > div:nth-child(1) > h2:nth-child(1)', {timeout: 30000});
-}
-
-const getFirstSelectableRecipient = () => {
-  return cy.get('li.selectable-list-item > draft-recipient:nth-child(1) > label:nth-child(1)', {timeout: 30000});
+  return cy.get('iframe[id="editor_ifr"]', {timeout:30000})
+    .its('0.contentDocument').should('exist')
+    .its('body')
+    .should('not.be.undefined')
+    .then(cy.wrap)
 }
 
 before(function setupAllocatedClient () {
@@ -35,7 +27,7 @@ before(function setupAllocatedClient () {
 
 beforeEach(function navigateToClient () {
   cy.get('@clientId').then(clientId => {
-    cy.visit('/supervision#/clients/' + clientId);
+    cy.visit(`/supervision/#/clients/${clientId}`);
   });
 });
 
@@ -44,33 +36,43 @@ describe('Creating, editing and retrieving a letter', { tags: ['@supervision', '
     'Given I\'m a Case Manager on Supervision creating a letter template' +
     'Then the letter is edited as expected',
     () => {
-      cy.get('.title-person-name', {timeout: 30000}).contains('Ted Tedson');
+      cy.get('.title-person-name').contains('Ted Tedson');
 
       cy.get('@orderId').then(orderId => {
         cy.get('@clientId').then(clientId => {
-          cy.visit('/supervision/#/clients/' + clientId + '/orders/' + orderId + '/drafts/create/template');
+          cy.visit(`/supervision/#/clients/${clientId}/orders/${orderId}/drafts/create/template`);
         });
       });
 
-      cy.get('.select-template', {timeout: 30000}).contains('Select a template');
+      cy.contains('.select-template', 'Select a template')
       cy.contains('blank: Blank template').click();
 
-      getRecipientHeader().contains('Select recipient/s');
-      getFirstSelectableRecipient().click();
+      cy.get('draft-select-recipients')
+        .find('.section-title')
+        .contains('Select recipient/s');
+
+      cy.get('li.selectable-list-item > draft-recipient:nth-child(1) > label:nth-child(1)')
+        .as('firstSelectableRecipient')
+        .click();
 
       cy.get('#create-letter-button').click();
-      cy.get('#preview-publish-button', {timeout:30000}).contains('Preview & publish');
-      cy.get('.document-editor__sub-title', {timeout:30000}).contains('Edit document...');
+      cy.contains('#preview-publish-button', 'Preview & publish');
+      cy.contains('.document-editor__sub-title', 'Edit document...');
+
+      cy.get('iframe[id="editor_ifr"]')
+        .its('0.contentDocument').should('exist')
+        .its('body').should('not.be.undefined')
+        .then(cy.wrap).as('iframeBody');
 
       getIframeBody().find("section").clear();
       getIframeBody().find("p").type("My test letter content");
 
       cy.get('#save-draft-and-exit-button').click();
-      cy.get('#publish-close-button', {timeout:30000}).click();
-      cy.get('#retrieve-drafts-button', {timeout:30000}).should('not.be.disabled').click();
-      cy.get('#preview-publish-button', {timeout:30000}).contains('Preview & publish');
+      cy.get('#publish-close-button').click();
+      cy.get('#retrieve-drafts-button').should('not.be.disabled').click();
+      cy.contains('#preview-publish-button', 'Preview & publish');
 
-      getIframeBody().contains("My test letter content");
+      getIframeBody().contains( 'My test letter content');
     }
   );
 });


### PR DESCRIPTION
Aliases the form container, allowing Cypress to handle retries until the form is reattached