### PR TITLE
sw-5435: Edit client v2

### DIFF
--- a/cypress/integration/supervision/clients/edit-client.spec.js
+++ b/cypress/integration/supervision/clients/edit-client.spec.js
@@ -3,8 +3,7 @@
   cy.createAClient();
 });
 
-//TODO: sw-5435 - Triaged. Passing in GH Actions build, fails main Sirius Jenkins pipeline
-describe.skip('Edit a client', { tags: ['@supervision', 'client', '@smoke-journey'] }, () => {
+describe('Edit a client', { tags: ['@supervision', 'client', '@smoke-journey'] }, () => {
   it(
     'Given I\'m a Case Manager on Supervision and on the client dashboard page' +
     'Then the Client Dashboard page loads as expected',
@@ -19,13 +18,10 @@ describe.skip('Edit a client', { tags: ['@supervision', 'client', '@smoke-journe
       const lastName = 'Billson' + suffix;
       const memorablePhrase = 'Memorable' + suffix
 
-      cy.get('#editClientFormContent').as('edit-panel');
-      cy.get('@edit-panel').within(() => {
-        cy.get('input[name="firstName"]').clear().type(firstName);
-        cy.get('input[name="lastName"]').clear().type(lastName);
-        cy.get('input[name="memorablePhrase"]').clear().type(memorablePhrase);
-        cy.contains('Save & Exit').click();
-      });
+      cy.get('#editClientFormContent > form').find('input[name="firstName"]').clear().type(firstName);
+      cy.get('#editClientFormContent > form').find('input[name="lastName"]').clear().type(lastName);
+      cy.get('#editClientFormContent > form').find('input[name="memorablePhrase"]').clear().type(memorablePhrase);
+      cy.get('#editClientFormContent > form').contains('Save & Exit').click();
 
       cy.get('.right-side').contains('.sub-section-header', 'Client details');
       cy.contains('.client-summary-full-name-value', `${firstName} ${lastName}`);


### PR DESCRIPTION
Re-queries the DOM for the form on each form field as the form somehow detatches in between fetching it and _immediately_ finding the next selector, and aliases are references to DOM elements, not a shorthand to fetching them (so not aliases)