### PR TITLE
Temporarily remove the change status tests

### DIFF
--- a/cypress/integration/lpa/cases/change-status.spec.js
+++ b/cypress/integration/lpa/cases/change-status.spec.js
@@ -1,31 +1,33 @@
-before(() => {
-  cy.loginAs("LPA Manager");
-  cy.createDonor().then(({ id: donorId }) => {
-    cy.createLpa(donorId).then(({ id: lpaId }) => {
-      cy.wrap(donorId).as("donorId");
-      cy.wrap(lpaId).as("lpaId");
-    });
-  });
-});
+// before(() => {
+//   cy.loginAs("LPA Manager");
+//   cy.createDonor().then(({ id: donorId }) => {
+//     cy.createLpa(donorId).then(({ id: lpaId }) => {
+//       cy.wrap(donorId).as("donorId");
+//       cy.wrap(lpaId).as("lpaId");
+//     });
+//   });
+// });
 
-describe("Change LPA status", { tags: ["@lpa", "@smoke-journey"] }, () => {
-  it("should change an LPA status", function () {
-    cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+// describe("Change LPA status", { tags: ["@lpa", "@smoke-journey"] }, () => {
+//   it("should change an LPA status", function () {
+//     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
 
-    cy.get(".case-tile-status").contains("Pending");
+//     cy.get(".case-tile-status").contains("Pending");
 
-    cy.contains("LPA (Create / Edit)");
+//     cy.contains("LPA (Create / Edit)");
 
-    cy.contains("Change Status").click();
-    cy.get("#status0").click();
-    cy.get("#status0").contains("Perfect").click();
-    cy.contains("Submit").click();
+//     cy.contains("Change Status").click();
+//     cy.frameLoaded(".action-widget-content iframe");
+//     cy.enter(".action-widget-content iframe").then((getBody) => {
+//       getBody().find("#f-status").select("Perfect");
+//       getBody().contains("button", "Submit").click();
+//     });
 
-    cy.contains(".case-tile-status", "Perfect");
+//     cy.contains(".case-tile-status", "Perfect");
 
-    cy.get(".timeline-event").first().contains("h2", "LPA (Create / Edit)");
-    cy.get(".timeline-event")
-      .first()
-      .contains("p", "Status changed from Pending to Perfect");
-  });
-});
+//     cy.get(".timeline-event").first().contains("h2", "LPA (Create / Edit)");
+//     cy.get(".timeline-event")
+//       .first()
+//       .contains("p", "Status changed from Pending to Perfect");
+//   });
+// });


### PR DESCRIPTION
They'll be replaced with a iframe-based test once the widget is enabled.

For VEGA-1238 #patch