### PR TITLE
Wait on DOM elements, not XHR requests

### DIFF
--- a/cypress/e2e/lpa/cases/administration.cy.js
+++ b/cypress/e2e/lpa/cases/administration.cy.js
@@ -1,38 +1,47 @@
-describe("LPA administration changes", { tags: ["@lpa", "@smoke-journey"] }, () => {
-  beforeEach(() => {
-    cy.loginAs("System Admin");
-    cy.createDonor().then(({ id: donorId }) => {
-      cy.createLpa(donorId).then(({ id: lpaId }) => {
-        cy.wrap(donorId).as("donorId");
-        cy.wrap(lpaId).as("lpaId");
+describe(
+  "LPA administration changes",
+  { tags: ["@lpa", "@smoke-journey"] },
+  () => {
+    beforeEach(() => {
+      cy.loginAs("System Admin");
+      cy.createDonor().then(({ id: donorId }) => {
+        cy.createLpa(donorId).then(({ id: lpaId }) => {
+          cy.wrap(donorId).as("donorId");
+          cy.wrap(lpaId).as("lpaId");
+        });
       });
     });
-  });
 
-  it("should change the LPA receipt date", function () {
-    cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+    it("should change the LPA receipt date", function () {
+      cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
 
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as("eventsRequest");
-    cy.intercept({ method: "GET", url: "/*/v1/cases/*" }).as("casesRequest");
+      cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as("eventsRequest");
+      cy.intercept({ method: "GET", url: "/*/v1/cases/*" }).as("casesRequest");
 
-    cy.wait("@eventsRequest");
+      cy.get(".case-tile-status").contains("Pending");
 
-    cy.get("uib-tab-heading[id=Administration]").contains("Administration").click();
-    cy.contains("Edit Dates").click();
+      cy.get("uib-tab-heading[id=Administration]")
+        .contains("Administration")
+        .click();
+      cy.contains("Edit Dates").click();
 
-    cy.wait("@casesRequest");
+      cy.wait("@casesRequest");
 
-    cy.frameLoaded('.action-widget-content iframe');
-    cy.enter('.action-widget-content iframe').then(getBody => {
-      getBody().find('#f-receiptDate').clear().type('2019-04-13');
-      getBody().find("button[type=submit]").click();
+      cy.frameLoaded(".action-widget-content iframe");
+      cy.enter(".action-widget-content iframe").then((getBody) => {
+        getBody().find("#f-receiptDate").clear().type("2019-04-13");
+        getBody().find("button[type=submit]").click();
+      });
+
+      cy.wait("@eventsRequest");
+
+      cy.contains(
+        ".timeline-event",
+        "Receipt date: 02/04/2019 changed to: 13/04/2019"
+      );
     });
-
-    cy.wait("@eventsRequest");
-
-    cy.contains(".timeline-event", "Receipt date: 02/04/2019 changed to: 13/04/2019");
-  });
-});
+  }
+);
 
 describe("Visit Admin Service", { tags: ["@lpa", "@smoke-journey"] }, () => {
   beforeEach(() => {
@@ -43,8 +52,8 @@ describe("Visit Admin Service", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.visit(`/lpa/home`);
 
     cy.contains("Admin").click();
-    assert(cy.contains('Sirius Admin'));
-    assert(cy.contains('Personal details'));
-    assert(cy.contains('2manager@opgtest.com'));
+    assert(cy.contains("Sirius Admin"));
+    assert(cy.contains("Personal details"));
+    assert(cy.contains("2manager@opgtest.com"));
   });
 });

--- a/cypress/e2e/lpa/cases/allocate-case.cy.js
+++ b/cypress/e2e/lpa/cases/allocate-case.cy.js
@@ -9,23 +9,28 @@ describe("Allocate case", { tags: ["@lpa", "@smoke-journey"] }, () => {
   });
 
   it("should allocate the LPA", function () {
-    cy.intercept({ method: 'GET', url: '/*/v1/persons/*/events*' }).as('eventsRequest');
+    cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as(
+      "eventsRequest"
+    );
 
-    cy.wait('@eventsRequest');
+    cy.get(".case-tile-status").contains("Pending");
 
-    cy.get('#Workflow').click();
-    cy.contains('Allocate Case').click();
+    cy.get("#Workflow").click();
+    cy.contains("Allocate Case").click();
 
-    cy.frameLoaded('.action-widget-content iframe');
-    cy.enter('.action-widget-content iframe').then(getBody => {
-      getBody().find('#f-assignTo-2').check();
-      getBody().find('#f-assigneeTeam').select('Complaints Team');
-      getBody().find('button[type=submit]').click();
+    cy.frameLoaded(".action-widget-content iframe");
+    cy.enter(".action-widget-content iframe").then((getBody) => {
+      getBody().find("#f-assignTo-2").check();
+      getBody().find("#f-assigneeTeam").select("Complaints Team");
+      getBody().find("button[type=submit]").click();
     });
 
-    cy.wait('@eventsRequest');
+    cy.wait("@eventsRequest");
 
-    cy.get('.timeline .timeline-event', { timeout: 10000 });
-    cy.contains('.timeline-event', 'Case was assigned to !Manager Team now assigned to Complaints Team');
+    cy.get(".timeline .timeline-event", { timeout: 10000 });
+    cy.contains(
+      ".timeline-event",
+      "Case was assigned to !Manager Team now assigned to Complaints Team"
+    );
   });
 });

--- a/cypress/e2e/lpa/cases/create-event.cy.js
+++ b/cypress/e2e/lpa/cases/create-event.cy.js
@@ -1,33 +1,34 @@
-describe('Create an event', { tags: ["@lpa", "@smoke-journey"] }, () => {
+describe("Create an event", { tags: ["@lpa", "@smoke-journey"] }, () => {
   before(() => {
-    cy.loginAs('LPA Manager');
-    cy.createDonor().then(({ id: donorId }) => {
+    cy.loginAs("LPA Manager");
+    cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
+      cy.wrap(donorUid).as("donorUid");
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
       });
     });
   });
 
-  it('should show the event', () => {
-    cy.intercept({ method: 'GET', url: '/*/v1/persons/*' }).as('personRequest');
+  it("should show the event", function () {
+    cy.intercept({ method: "GET", url: "/*/v1/persons/*" }).as("personRequest");
 
-    cy.wait('@personRequest');
+    cy.get(".person-panel-details").contains(this.donorUid);
 
-    cy.contains('New Event').click();
+    cy.contains("New Event").click();
 
-    cy.frameLoaded('.action-widget-content iframe');
-    cy.enter('.action-widget-content iframe').then(getBody => {
-      getBody().find('#f-type').select('Application returned');
-      getBody().find('#f-name').type('Sent back');
-      getBody().find('#f-description').type('For good reasons');
-      getBody().find('button[type=submit]').click();
+    cy.frameLoaded(".action-widget-content iframe");
+    cy.enter(".action-widget-content iframe").then((getBody) => {
+      getBody().find("#f-type").select("Application returned");
+      getBody().find("#f-name").type("Sent back");
+      getBody().find("#f-description").type("For good reasons");
+      getBody().find("button[type=submit]").click();
     });
 
-    cy.wait('@personRequest');
+    cy.wait("@personRequest");
 
-    cy.get('.timeline .timeline-event', { timeout: 10000 });
-    cy.contains('.timeline-event', 'Application returned')
-      .should('contain', 'Sent back')
-      .should('contain', 'For good reasons');
+    cy.get(".timeline .timeline-event", { timeout: 10000 });
+    cy.contains(".timeline-event", "Application returned")
+      .should("contain", "Sent back")
+      .should("contain", "For good reasons");
   });
 });

--- a/cypress/e2e/lpa/cases/create-relationship.cy.js
+++ b/cypress/e2e/lpa/cases/create-relationship.cy.js
@@ -1,7 +1,7 @@
 describe('Create a relationship', { tags: ["@lpa", "@smoke-journey"] }, () => {
   before(() => {
     cy.loginAs('LPA Manager');
-    cy.createDonor().then(({ id: donorId }) => {
+    cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
       cy.createDonor().then(({ uId: otherDonorUid }) => {
         cy.createLpa(donorId).then(({ id: lpaId }) => {
           cy.waitUntil(() =>
@@ -11,17 +11,17 @@ describe('Create a relationship', { tags: ["@lpa", "@smoke-journey"] }, () => {
           );
 
           cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+          cy.wrap(donorUid).as("donorUid");
           cy.wrap(otherDonorUid).as("otherDonorUid");
         });
       });
     });
   });
 
-  it('should show the relationship', () => {
-    cy.intercept({ method: 'GET', url: '/*/v1/persons/*' }).as('personRequest');
+  it('should show the relationship', function () {
     cy.intercept({ method: 'GET', url: '/*/v1/persons/*/references' }).as('referenceRequest');
 
-    cy.wait('@personRequest');
+    cy.get(".person-panel-details").contains(this.donorUid);
 
     cy.get("#Workflow").click();
     cy.contains("Create Relationship").click();

--- a/cypress/e2e/lpa/cases/documents.cy.js
+++ b/cypress/e2e/lpa/cases/documents.cy.js
@@ -2,14 +2,7 @@ describe("Documents", { tags: ["@lpa", "@smoke-journey"] }, () => {
   beforeEach(() => {
     cy.intercept({ method: "GET", url: "/*/v1/persons/*/cases" }).as("casesRequest");
     cy.intercept({ method: "GET", url: "/*/v1/templates/lpa" }).as("templatesRequest");
-    cy.intercept({ method: "GET", url: "/*/v1/lpas/*/draft-count" }).as("draftCountRequest");
-    cy.intercept({ method: "POST", url: "/*/v1/lpas/*/documents" }).as("documentsRequest");
-    cy.intercept({ method: "GET", url: "/*/v1/lpas/*/documents" }).as("getDocumentRequest");
     cy.intercept({ method: "POST", url: "/*/v1/lpas/*/documents/draft" }).as("draftRequest");
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/events?*" }).as("eventsRequest");
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/documents?*" }).as("documentsListRequest");
-    cy.intercept({ method: "HEAD", url: "/*/v1/documents/*/download" }).as("documentDownloadRequest");
-    cy.intercept({ method: "GET", url: "/*/v1/documents/*" }).as("documentGetRequest");
 
     cy.loginAs("LPA Manager");
     cy.createDonor().then(({ id: donorId }) => {

--- a/cypress/e2e/lpa/cases/tasks.cy.js
+++ b/cypress/e2e/lpa/cases/tasks.cy.js
@@ -10,9 +10,8 @@ describe('Create a task', { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it('should show the task', () => {
     cy.intercept({ method: 'GET', url: '/*/v1/persons/*/cases' }).as('casesRequest');
-    cy.intercept({ method: 'GET', url: '/*/v1/persons/*' }).as('personRequest');
 
-    cy.wait('@casesRequest');
+    cy.get(".case-tile-status").contains("Pending");
 
     cy.contains('New Task').click();
 

--- a/cypress/e2e/lpa/donors/donor.cy.js
+++ b/cypress/e2e/lpa/donors/donor.cy.js
@@ -28,7 +28,12 @@ describe("Create Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
         .contains("a", "View donor")
         .invoke("attr", "href")
         .then((donorLinkUrl) => {
-          cy.visit(donorLinkUrl.replace(/https?:\/\/localhost:8080/, Cypress.config('baseUrl')));
+          cy.visit(
+            donorLinkUrl.replace(
+              /https?:\/\/localhost:8080/,
+              Cypress.config("baseUrl")
+            )
+          );
 
           cy.get(".timeline .timeline-event", { timeout: 10000 });
           cy.contains(".timeline-event", "Person (Create / Edit)").should(
@@ -43,8 +48,9 @@ describe("Create Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
 describe("Edits a Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
   before(() => {
     cy.loginAs("Case Manager");
-    cy.createDonor().then(({ id }) => {
+    cy.createDonor().then(({ id, uId }) => {
       cy.wrap(id).as("donorId");
+      cy.wrap(uId).as("donorUid");
     });
   });
 
@@ -52,7 +58,7 @@ describe("Edits a Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.visit(`/lpa/#/person/${this.donorId}`);
     cy.intercept({ method: "GET", url: "/*/v1/persons/*" }).as("personRequest");
 
-    cy.wait("@personRequest");
+    cy.get(".person-panel-details").contains(this.donorUid);
 
     cy.contains("Edit Donor").click();
     cy.frameLoaded(".action-widget-content iframe");
@@ -61,10 +67,8 @@ describe("Edits a Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
       getBody().find("button[type=submit]").click();
     });
 
-    cy.wait("@personRequest");
-
     cy.get(".timeline-event")
-      .contains("First name: Bob changed to: Patrick", { timeout: 20000 })
+      .should("contain", "First name: Bob changed to: Patrick", { timeout: 20000 })
       .should("be.visible");
   });
 });


### PR DESCRIPTION
XHR-request-waiting isn't a particularly good technique in general, and we've specifically found that it sometimes is started after the XHR is already complete, causing the test to hang until failing.

Hence, replace some straightforward XHR-request-waiting with DOM-waiting to hopefully make some of our tests more reliable.

VEGA-1395 #patch