### PR TITLE
Removing remainin `personRequest` waits

### DIFF
--- a/cypress/e2e/lpa/cases/complaints.cy.js
+++ b/cypress/e2e/lpa/cases/complaints.cy.js
@@ -1,18 +1,19 @@
 describe('Complaints', { tags: ["@lpa", "@smoke-journey"] }, () => {
   before(() => {
     cy.loginAs('LPA Manager');
-    cy.createDonor().then(({ id: donorId }) => {
+    cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
+      cy.wrap(donorUid).as("donorUid");
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
       });
     });
   });
 
-  it('should add and edit a complaint', () => {
-    cy.intercept({ method: 'GET', url: '/*/v1/persons/*' }).as('personRequest');
+  it('should add and edit a complaint', function () {
     cy.intercept({ method: 'GET', url: '/*/v1/lpas/*/complaints' }).as('complaintsRequest');
 
-    cy.wait(['@complaintsRequest', '@personRequest']);
+    cy.wait(['@complaintsRequest']);
+    cy.get(".person-panel-details").contains(this.donorUid);
 
     cy.get('#AddComplaint').click();
 

--- a/cypress/e2e/lpa/cases/create-event.cy.js
+++ b/cypress/e2e/lpa/cases/create-event.cy.js
@@ -10,8 +10,6 @@ describe("Create an event", { tags: ["@lpa", "@smoke-journey"] }, () => {
   });
 
   it("should show the event", function () {
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*" }).as("personRequest");
-
     cy.get(".person-panel-details").contains(this.donorUid);
 
     cy.contains("New Event").click();
@@ -23,8 +21,6 @@ describe("Create an event", { tags: ["@lpa", "@smoke-journey"] }, () => {
       getBody().find("#f-description").type("For good reasons");
       getBody().find("button[type=submit]").click();
     });
-
-    cy.wait("@personRequest");
 
     cy.get(".timeline .timeline-event", { timeout: 10000 });
     cy.contains(".timeline-event", "Application returned")

--- a/cypress/e2e/lpa/cases/warnings.cy.js
+++ b/cypress/e2e/lpa/cases/warnings.cy.js
@@ -1,7 +1,8 @@
 describe('Warnings', { tags: ["@lpa", "@smoke-journey"] }, () => {
   before(() => {
     cy.loginAs('LPA Manager');
-    cy.createDonor().then(({ id: donorId }) => {
+    cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
+      cy.wrap(donorUid).as("donorUid");
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.wrap(`/lpa/#/person/${donorId}/${lpaId}`).as('url');
       });
@@ -9,13 +10,13 @@ describe('Warnings', { tags: ["@lpa", "@smoke-journey"] }, () => {
   });
 
   beforeEach(function () {
-    cy.intercept({ method: 'GET', url: '/*/v1/persons/*' }).as('personRequest');
     cy.intercept({ method: 'GET', url: '/*/v1/persons/*/warnings' }).as('warningsRequest');
     cy.intercept({ method: 'DELETE', url: '/*/v1/warnings/*' }).as('deleteRequest');
 
     cy.loginAs('LPA Manager');
     cy.visit(this.url);
-    cy.wait(['@personRequest', '@warningsRequest']);
+    cy.wait(['@warningsRequest']);
+    cy.get(".person-panel-details").contains(this.donorUid);
   });
 
   it('should create a warning', () => {


### PR DESCRIPTION
These are still occasionally failing on Deploy to Dev. Since the wait-for-content method worked well for other tests, shift hese over too.

Also remove a useless wait from create-event: the timeline update is what we actually want to check.

#patch