### PR TITLE
Don't run local tests as Dependabot

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -72,6 +72,7 @@ jobs:
           registries: 311462405659
 
       - name: Run Tests against local Sirius
+        if: github.actor != 'dependabot[bot]'
         run: |
           make unpack-sirius-components
           make pull-sirius-containers


### PR DESCRIPTION

Dependabot doesn't have the required secrets to pull the latest green build from ECR

#patch