### PR TITLE
Don't double-enter the person search form

### DIFF
--- a/cypress/e2e/lpa/donors/link.cy.js
+++ b/cypress/e2e/lpa/donors/link.cy.js
@@ -30,7 +30,6 @@ describe("Link donors", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.frameLoaded(".action-widget-content iframe");
     cy.enter(".action-widget-content iframe").then((getBody) => {
       getBody().find("#f-uid").type(`${this.secondaryDonorUid}{enter}`);
-      getBody().contains("button", "Search").click();
     });
 
     cy.wait(3000);


### PR DESCRIPTION
`.type('{enter}')` and `("button").click()` are both submitting the form, we don't need both of them

#patch