### PR TITLE
Fix widget CSS selector

### DIFF
--- a/cypress/e2e/lpa/cases/epa.cy.js
+++ b/cypress/e2e/lpa/cases/epa.cy.js
@@ -12,8 +12,8 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.contains("Create EPA Case").click();
 
     cy.get(".action-widget-content:visible").within(() => {
-      cy.get("#epaDonorSignatureDate0").type("21/09/2007");
-      cy.get("#epaDonorNoticeGivenDate0").type("21/09/2007", { force: true });
+      cy.get("#epaDonorSignatureDate0").type("21/09/2007{esc}");
+      cy.get("#epaDonorNoticeGivenDate0").type("21/09/2007{esc}");
 
       cy.contains(
         "To your knowledge, has the donor made any other Enduring Powers of Attorney?"

--- a/cypress/e2e/lpa/cases/epa.cy.js
+++ b/cypress/e2e/lpa/cases/epa.cy.js
@@ -11,7 +11,7 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.contains("Create EPA Case").click();
 
-    cy.get(".action-widget-content").within(() => {
+    cy.get(".action-widget-content:visible").within(() => {
       cy.get("#epaDonorSignatureDate0").type("21/09/2007");
       cy.get("#epaDonorNoticeGivenDate0").type("21/09/2007", { force: true });
 
@@ -49,7 +49,7 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.contains("Edit Case").click();
 
-    cy.get(".action-widget-content").within(() => {
+    cy.get(".action-widget-content:visible").within(() => {
       cy.contains("Case actors").click();
       cy.contains("Add an Attorney").click();
 

--- a/cypress/e2e/lpa/cases/lpa.cy.js
+++ b/cypress/e2e/lpa/cases/lpa.cy.js
@@ -11,7 +11,7 @@ describe("Create LPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.contains("Create LPA Case").click();
 
-    cy.get(".action-widget-content").within(() => {
+    cy.get(".action-widget-content:visible").within(() => {
       cy.contains("hw").click();
       cy.contains("Online").click();
       cy.get("#onlineLpaId0").type("A123456789");
@@ -100,7 +100,7 @@ describe("Edit LPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.contains("Edit Case").click();
 
-    cy.get(".action-widget-content").within(() => {
+    cy.get(".action-widget-content:visible").within(() => {
       cy.contains("LP2 Application Form").click();
       cy.contains("Add Correspondent").click();
 


### PR DESCRIPTION
`.action-widget-content` has started matching hidden elements, and `.within()` only works if a single element has been found. Specify that we're only interested in the visible one.

#patch