### PR TITLE
Attempt to fix a few common E2E issues

### DIFF
--- a/cypress/e2e/lpa/cases/create-event.cy.js
+++ b/cypress/e2e/lpa/cases/create-event.cy.js
@@ -3,7 +3,8 @@ describe("Create an event", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.loginAs("LPA Manager");
     cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
       cy.wrap(donorUid).as("donorUid");
-      cy.createLpa(donorId).then(({ id: lpaId }) => {
+      cy.createLpa(donorId).then(({ id: lpaId, uId: lpaUid }) => {
+        cy.wrap(lpaUid).as("lpaUid");
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
       });
     });
@@ -11,6 +12,7 @@ describe("Create an event", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should show the event", function () {
     cy.get(".person-panel-details").contains(this.donorUid);
+    cy.get(".case-tile-container .case").contains(this.lpaUid);
 
     cy.contains("New Event").click();
 

--- a/cypress/e2e/lpa/cases/investigations.cy.js
+++ b/cypress/e2e/lpa/cases/investigations.cy.js
@@ -3,7 +3,8 @@ describe("Create an investigation", { tags: ["@lpa", "@smoke-journey"] }, () => 
     cy.loginAs("System Admin");
     cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
       cy.wrap(donorUid).as("donorUid");
-      cy.createLpa(donorId).then(({ id: lpaId }) => {
+      cy.createLpa(donorId).then(({ id: lpaId, uId: lpaUid }) => {
+        cy.wrap(lpaUid).as("lpaUid");
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
       });
     });
@@ -11,6 +12,7 @@ describe("Create an investigation", { tags: ["@lpa", "@smoke-journey"] }, () => 
 
   it("should create an investigation on the LPA", function () {
     cy.get(".person-panel-details").contains(this.donorUid);
+    cy.get(".case-tile-container .case").contains(this.lpaUid);
 
     cy.contains("Add Investigation").click();
 

--- a/cypress/e2e/lpa/cases/tasks.cy.js
+++ b/cypress/e2e/lpa/cases/tasks.cy.js
@@ -64,6 +64,8 @@ describe("Complete a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.wait("@getTasksRequest");
 
+    cy.get(".task-list").scrollIntoView();
+
     cy.get(".task-list").contains("Complete Create physical case file").click();
     cy.contains("Yes, confirm").click();
 
@@ -94,6 +96,8 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.wait("@eventsRequest");
     cy.wait("@getTasksRequest");
+
+    cy.get(".task-list").scrollIntoView();
 
     cy.contains(
       ".task-actions .icon-button",


### PR DESCRIPTION
- Wait for the *case* to load, not just the donor, since the widgets rely on having a "selected case"
- When interacting with the task list, scroll it into view first to ensure that the buttons aren't covered by other fixed elements (e.g. the page header)

Fixes VEGA-1718 #patch