### PR TITLE
SW-6445 Attempt to fix some flakiness

### DIFF
--- a/cypress/e2e/lpa/cases/administration.cy.js
+++ b/cypress/e2e/lpa/cases/administration.cy.js
@@ -14,7 +14,6 @@ describe(
 
     it("should change the LPA receipt date", function () {
       cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
-      cy.waitForStableDOM();
 
       cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as(
         "eventsRequest"
@@ -22,6 +21,8 @@ describe(
       cy.intercept({ method: "GET", url: "/*/v1/cases/*" }).as("casesRequest");
 
       cy.get(".case-tile-status").contains("Pending");
+
+      cy.waitForStableDOM();
 
       cy.get("uib-tab-heading[id=Administration]")
         .contains("Administration")

--- a/cypress/e2e/lpa/cases/administration.cy.js
+++ b/cypress/e2e/lpa/cases/administration.cy.js
@@ -14,6 +14,7 @@ describe(
 
     it("should change the LPA receipt date", function () {
       cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+      cy.waitForStableDOM();
 
       cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as(
         "eventsRequest"

--- a/cypress/e2e/lpa/cases/allocate-case.cy.js
+++ b/cypress/e2e/lpa/cases/allocate-case.cy.js
@@ -4,6 +4,7 @@ describe("Allocate case", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });

--- a/cypress/e2e/lpa/cases/allocate-case.cy.js
+++ b/cypress/e2e/lpa/cases/allocate-case.cy.js
@@ -4,7 +4,6 @@ describe("Allocate case", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-        cy.waitForStableDOM();
       });
     });
   });
@@ -16,6 +15,7 @@ describe("Allocate case", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.get(".case-tile-status").contains("Pending");
 
+    cy.waitForStableDOM();
     cy.get("#Workflow").click();
     cy.contains("Allocate Case").click();
 

--- a/cypress/e2e/lpa/cases/change-status.cy.js
+++ b/cypress/e2e/lpa/cases/change-status.cy.js
@@ -11,6 +11,7 @@ before(() => {
 describe("Change LPA status", { tags: ["@lpa", "@smoke-journey"] }, () => {
   it("should change an LPA status", function () {
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+    cy.waitForStableDOM();
 
     cy.get(".case-tile-status").contains("Pending");
 
@@ -20,14 +21,14 @@ describe("Change LPA status", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.frameLoaded(".action-widget-content iframe");
     cy.enter(".action-widget-content iframe").then((getBody) => {
       getBody().find("#f-status").select("Perfect");
+      cy.wrap(getBody);
+    }).then((getBody) => {
       getBody().contains("button", "Submit").click();
     });
 
     cy.contains(".case-tile-status", "Perfect");
 
     cy.get(".timeline-event").first().contains("h2", "LPA (Create / Edit)");
-    cy.get(".timeline-event")
-      .first()
-      .contains("p", "Status changed from Pending to Perfect");
+    cy.get(".timeline-event").first().contains("p", "Status changed from Pending to Perfect");
   });
 });

--- a/cypress/e2e/lpa/cases/complaints.cy.js
+++ b/cypress/e2e/lpa/cases/complaints.cy.js
@@ -5,6 +5,7 @@ describe("Complaints", { tags: ["@lpa", "@smoke-journey"] }, () => {
       cy.wrap(donorUid).as("donorUid");
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });

--- a/cypress/e2e/lpa/cases/complaints.cy.js
+++ b/cypress/e2e/lpa/cases/complaints.cy.js
@@ -5,7 +5,6 @@ describe("Complaints", { tags: ["@lpa", "@smoke-journey"] }, () => {
       cy.wrap(donorUid).as("donorUid");
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-        cy.waitForStableDOM();
       });
     });
   });
@@ -18,6 +17,7 @@ describe("Complaints", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.wait(["@complaintsRequest"]);
     cy.get(".person-panel-details").contains(this.donorUid);
 
+    cy.waitForStableDOM();
     cy.get("#AddComplaint").click();
 
     cy.frameLoaded(".action-widget-content iframe");

--- a/cypress/e2e/lpa/cases/create-event.cy.js
+++ b/cypress/e2e/lpa/cases/create-event.cy.js
@@ -6,6 +6,7 @@ describe("Create an event", { tags: ["@lpa", "@smoke-journey"] }, () => {
       cy.createLpa(donorId).then(({ id: lpaId, uId: lpaUid }) => {
         cy.wrap(lpaUid).as("lpaUid");
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });

--- a/cypress/e2e/lpa/cases/create-relationship.cy.js
+++ b/cypress/e2e/lpa/cases/create-relationship.cy.js
@@ -16,6 +16,7 @@ describe("Create a relationship", { tags: ["@lpa", "@smoke-journey"] }, () => {
           );
 
           cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+          cy.waitForStableDOM();
           cy.wrap(donorUid).as("donorUid");
           cy.wrap(otherDonorUid).as("otherDonorUid");
         });

--- a/cypress/e2e/lpa/cases/create-relationship.cy.js
+++ b/cypress/e2e/lpa/cases/create-relationship.cy.js
@@ -16,7 +16,6 @@ describe("Create a relationship", { tags: ["@lpa", "@smoke-journey"] }, () => {
           );
 
           cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-          cy.waitForStableDOM();
           cy.wrap(donorUid).as("donorUid");
           cy.wrap(otherDonorUid).as("otherDonorUid");
         });
@@ -31,6 +30,7 @@ describe("Create a relationship", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.get(".person-panel-details").contains(this.donorUid);
 
+    cy.waitForStableDOM();
     cy.get("#Workflow").click();
     cy.contains("Create Relationship").click();
 

--- a/cypress/e2e/lpa/cases/documents.cy.js
+++ b/cypress/e2e/lpa/cases/documents.cy.js
@@ -15,9 +15,10 @@ describe("Documents", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should create a draft with an insert", function () {
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
-    cy.waitForStableDOM();
+
     cy.wait("@casesRequest");
 
+    cy.waitForStableDOM();
     cy.get("#CreateDocument").click();
 
     cy.frameLoaded(".action-widget-content iframe");

--- a/cypress/e2e/lpa/cases/documents.cy.js
+++ b/cypress/e2e/lpa/cases/documents.cy.js
@@ -15,6 +15,7 @@ describe("Documents", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should create a draft with an insert", function () {
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+    cy.waitForStableDOM();
     cy.wait("@casesRequest");
 
     cy.get("#CreateDocument").click();

--- a/cypress/e2e/lpa/cases/epa.cy.js
+++ b/cypress/e2e/lpa/cases/epa.cy.js
@@ -8,8 +8,8 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should create an EPA", function () {
     cy.visit(`/lpa/#/person/${this.donorId}`);
-    cy.waitForStableDOM();
 
+    cy.waitForStableDOM();
     cy.contains("Create EPA Case").click();
 
     cy.get(".action-widget-content:visible").within(() => {
@@ -44,11 +44,11 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
       "eventsRequest"
     );
     cy.visit(this.epaUrl);
-    cy.waitForStableDOM();
 
     cy.wait("@eventsRequest");
     cy.contains(".case-tile-status", "Pending");
 
+    cy.waitForStableDOM();
     cy.contains("Edit Case").click();
 
     cy.get(".action-widget-content:visible").within(() => {
@@ -72,7 +72,6 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.get(".timeline").contains(".timeline-event h2", "Attorney");
 
-    cy.waitForStableDOM();
     cy.get(".opg-icon").contains("CasePeople").click({ force: true });
 
     cy.get(".person-info")

--- a/cypress/e2e/lpa/cases/epa.cy.js
+++ b/cypress/e2e/lpa/cases/epa.cy.js
@@ -8,6 +8,7 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should create an EPA", function () {
     cy.visit(`/lpa/#/person/${this.donorId}`);
+    cy.waitForStableDOM();
 
     cy.contains("Create EPA Case").click();
 
@@ -43,6 +44,7 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
       "eventsRequest"
     );
     cy.visit(this.epaUrl);
+    cy.waitForStableDOM();
 
     cy.wait("@eventsRequest");
     cy.contains(".case-tile-status", "Pending");
@@ -70,6 +72,7 @@ describe("Create EPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.get(".timeline").contains(".timeline-event h2", "Attorney");
 
+    cy.waitForStableDOM();
     cy.get(".opg-icon").contains("CasePeople").click({ force: true });
 
     cy.get(".person-info")

--- a/cypress/e2e/lpa/cases/investigations.cy.js
+++ b/cypress/e2e/lpa/cases/investigations.cy.js
@@ -6,6 +6,7 @@ describe("Create an investigation", { tags: ["@lpa", "@smoke-journey"] }, () => 
       cy.createLpa(donorId).then(({ id: lpaId, uId: lpaUid }) => {
         cy.wrap(lpaUid).as("lpaUid");
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });
@@ -42,6 +43,7 @@ describe("Put investigation on hold", { tags: ["@lpa", "@smoke-journey"] }, () =
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
         cy.createInvestigation(lpaId);
+        cy.waitForStableDOM();
       });
     });
   });
@@ -56,6 +58,8 @@ describe("Put investigation on hold", { tags: ["@lpa", "@smoke-journey"] }, () =
       getBody().contains("Aspect")
       getBody().contains("10/04/2022")
       getBody().find("#f-reason").check();
+      cy.wrap(getBody);
+    }).then((getBody) => {
       getBody().find("button[type=submit]").click();
     });
 
@@ -74,6 +78,7 @@ describe("Take investigation off hold", { tags: ["@lpa", "@smoke-journey"] }, ()
         cy.createInvestigation(lpaId).then(({ id: investigationId }) => {
           cy.putInvestigationOnHold(investigationId);
         });
+        cy.waitForStableDOM();
       });
     });
   });
@@ -88,6 +93,8 @@ describe("Take investigation off hold", { tags: ["@lpa", "@smoke-journey"] }, ()
       getBody().contains("Aspect")
       getBody().contains("10/04/2022")
       getBody().contains("Police Investigation")
+      cy.wrap(getBody);
+    }).then((getBody) => {
       getBody().find("button[type=submit]").click();
     });
 

--- a/cypress/e2e/lpa/cases/investigations.cy.js
+++ b/cypress/e2e/lpa/cases/investigations.cy.js
@@ -6,7 +6,6 @@ describe("Create an investigation", { tags: ["@lpa", "@smoke-journey"] }, () => 
       cy.createLpa(donorId).then(({ id: lpaId, uId: lpaUid }) => {
         cy.wrap(lpaUid).as("lpaUid");
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-        cy.waitForStableDOM();
       });
     });
   });
@@ -15,6 +14,7 @@ describe("Create an investigation", { tags: ["@lpa", "@smoke-journey"] }, () => 
     cy.get(".person-panel-details").contains(this.donorUid);
     cy.get(".case-tile-container .case").contains(this.lpaUid);
 
+    cy.waitForStableDOM();
     cy.contains("Add Investigation").click();
     cy.wait(2000);
 
@@ -43,12 +43,12 @@ describe("Put investigation on hold", { tags: ["@lpa", "@smoke-journey"] }, () =
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
         cy.createInvestigation(lpaId);
-        cy.waitForStableDOM();
       });
     });
   });
 
   it("should put an investigation on hold", function () {
+    cy.waitForStableDOM();
     cy.get(".investigation-item").contains("Objections").click();
     cy.wait(2000);
 
@@ -78,12 +78,12 @@ describe("Take investigation off hold", { tags: ["@lpa", "@smoke-journey"] }, ()
         cy.createInvestigation(lpaId).then(({ id: investigationId }) => {
           cy.putInvestigationOnHold(investigationId);
         });
-        cy.waitForStableDOM();
       });
     });
   });
 
   it("should take an investigation off hold", function () {
+    cy.waitForStableDOM();
     cy.get(".investigation-item").contains("Objections").click();
     cy.wait(2000);
 

--- a/cypress/e2e/lpa/cases/investigations.cy.js
+++ b/cypress/e2e/lpa/cases/investigations.cy.js
@@ -15,6 +15,7 @@ describe("Create an investigation", { tags: ["@lpa", "@smoke-journey"] }, () => 
     cy.get(".case-tile-container .case").contains(this.lpaUid);
 
     cy.contains("Add Investigation").click();
+    cy.wait(2000);
 
     cy.frameLoaded(".action-widget-content iframe");
     cy.enter(".action-widget-content iframe").then((getBody) => {

--- a/cypress/e2e/lpa/cases/lpa.cy.js
+++ b/cypress/e2e/lpa/cases/lpa.cy.js
@@ -8,6 +8,7 @@ describe("Create LPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should create a Health and Welfare LPA", function () {
     cy.visit(`/lpa/#/person/${this.donorId}`);
+    cy.waitForStableDOM();
 
     cy.contains("Create LPA Case").click();
 
@@ -95,6 +96,7 @@ describe("Edit LPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should add a correspondent", function () {
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+    cy.waitForStableDOM();
 
     cy.contains(".case-tile-status", "Pending");
 

--- a/cypress/e2e/lpa/cases/lpa.cy.js
+++ b/cypress/e2e/lpa/cases/lpa.cy.js
@@ -8,8 +8,8 @@ describe("Create LPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should create a Health and Welfare LPA", function () {
     cy.visit(`/lpa/#/person/${this.donorId}`);
-    cy.waitForStableDOM();
 
+    cy.waitForStableDOM();
     cy.contains("Create LPA Case").click();
 
     cy.get(".action-widget-content:visible").within(() => {
@@ -96,10 +96,10 @@ describe("Edit LPA", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should add a correspondent", function () {
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
-    cy.waitForStableDOM();
 
     cy.contains(".case-tile-status", "Pending");
 
+    cy.waitForStableDOM();
     cy.contains("Edit Case").click();
 
     cy.get(".action-widget-content:visible").within(() => {

--- a/cypress/e2e/lpa/cases/search.cy.js
+++ b/cypress/e2e/lpa/cases/search.cy.js
@@ -11,6 +11,7 @@ describe("Searching for a case", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("selected search result navigates user to the correct case", function () {
     cy.visit(`/lpa/home`);
+    cy.waitForStableDOM();
 
     cy.get("#searchKeyword").type(`${this.lpaUid}`);
     cy.get(".search-form > form").submit();

--- a/cypress/e2e/lpa/cases/tasks.cy.js
+++ b/cypress/e2e/lpa/cases/tasks.cy.js
@@ -50,32 +50,17 @@ describe("Complete a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });
 
   it("a task completed timeline event is recorded", () => {
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as(
-      "eventsRequest"
-    );
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/tasks*" }).as(
-      "getTasksRequest"
-    );
-    cy.intercept({ method: "PUT", url: "/*/v1/*tasks/*" }).as("tasksRequest");
-
-    cy.wait("@getTasksRequest");
-
-    cy.waitForStableDOM();
-
     cy.get(".task-list").scrollIntoView();
-
-    cy.get(".task-list").contains("Complete Create physical case file").click();
-    cy.contains("Yes, confirm").click();
-
-    cy.wait("@eventsRequest");
-    cy.wait("@tasksRequest");
-
-    cy.contains(".timeline-event", "Create physical case file Completed");
+    cy.get(".task-list").contains("Complete Create physical case file").click().then(() => {
+      cy.contains("Yes, confirm").click();
+      cy.contains(".timeline-event", "Create physical case file Completed");
+    });
   });
 });
 
@@ -85,25 +70,13 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });
 
   it("a task reassign timeline event is recorded", () => {
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/events*" }).as(
-      "eventsRequest"
-    );
-    cy.intercept({ method: "GET", url: "/*/v1/persons/*/tasks*" }).as(
-      "getTasksRequest"
-    );
-
-    cy.wait("@eventsRequest");
-    cy.wait("@getTasksRequest");
-
-    cy.waitForStableDOM();
-
     cy.get(".task-list").scrollIntoView();
-
     cy.contains(
       ".task-actions .icon-button",
       "Allocate Create physical case file"
@@ -118,8 +91,6 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     }).then((getBody) => {
       getBody().find("button[type=submit]").click();
     });
-
-    cy.wait("@eventsRequest");
 
     cy.contains(
       ".timeline-event",

--- a/cypress/e2e/lpa/cases/tasks.cy.js
+++ b/cypress/e2e/lpa/cases/tasks.cy.js
@@ -4,6 +4,7 @@ describe("Create a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });
@@ -49,6 +50,7 @@ describe("Complete a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });
@@ -82,6 +84,7 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
+        cy.waitForStableDOM();
       });
     });
   });
@@ -109,6 +112,8 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
       getBody().should("contain", "Create physical case file");
       getBody().contains("label", "Team").parent().find("input").check();
       getBody().find("#f-assigneeTeam").select("Card Payment Team");
+      cy.wrap(getBody);
+    }).then((getBody) => {
       getBody().find("button[type=submit]").click();
     });
 

--- a/cypress/e2e/lpa/cases/tasks.cy.js
+++ b/cypress/e2e/lpa/cases/tasks.cy.js
@@ -4,7 +4,6 @@ describe("Create a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-        cy.waitForStableDOM();
       });
     });
   });
@@ -16,6 +15,7 @@ describe("Create a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.get(".case-tile-status").contains("Pending");
 
+    cy.waitForStableDOM();
     cy.contains("New Task").click();
 
     cy.frameLoaded(".action-widget-content iframe");
@@ -50,7 +50,6 @@ describe("Complete a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-        cy.waitForStableDOM();
       });
     });
   });
@@ -65,6 +64,8 @@ describe("Complete a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.intercept({ method: "PUT", url: "/*/v1/*tasks/*" }).as("tasksRequest");
 
     cy.wait("@getTasksRequest");
+
+    cy.waitForStableDOM();
 
     cy.get(".task-list").scrollIntoView();
 
@@ -84,7 +85,6 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.createDonor().then(({ id: donorId }) => {
       cy.createLpa(donorId).then(({ id: lpaId }) => {
         cy.visit(`/lpa/#/person/${donorId}/${lpaId}`);
-        cy.waitForStableDOM();
       });
     });
   });
@@ -99,6 +99,8 @@ describe("Reassign a task", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.wait("@eventsRequest");
     cy.wait("@getTasksRequest");
+
+    cy.waitForStableDOM();
 
     cy.get(".task-list").scrollIntoView();
 

--- a/cypress/e2e/lpa/cases/timeline.cy.js
+++ b/cypress/e2e/lpa/cases/timeline.cy.js
@@ -15,6 +15,7 @@ describe("Timeline", { tags: ["@lpa", "@smoke-journey"] }, () => {
     );
 
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
+    cy.waitForStableDOM();
 
     cy.wait("@eventsRequest");
 

--- a/cypress/e2e/lpa/cases/timeline.cy.js
+++ b/cypress/e2e/lpa/cases/timeline.cy.js
@@ -15,10 +15,10 @@ describe("Timeline", { tags: ["@lpa", "@smoke-journey"] }, () => {
     );
 
     cy.visit(`/lpa/#/person/${this.donorId}/${this.lpaId}`);
-    cy.waitForStableDOM();
 
     cy.wait("@eventsRequest");
 
+    cy.waitForStableDOM();
     cy.get(".timeline-facets").contains("Task").click();
 
     cy.wait("@eventsRequest");

--- a/cypress/e2e/lpa/cases/warnings.cy.js
+++ b/cypress/e2e/lpa/cases/warnings.cy.js
@@ -19,12 +19,12 @@ describe("Warnings", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.loginAs("LPA Manager");
     cy.visit(this.url);
-    cy.waitForStableDOM();
     cy.wait(["@warningsRequest"]);
     cy.get(".person-panel-details").contains(this.donorUid);
   });
 
   it("should create a warning", () => {
+    cy.waitForStableDOM();
     cy.contains("Create Warning").click();
 
     cy.frameLoaded(".action-widget-content iframe");
@@ -47,6 +47,7 @@ describe("Warnings", { tags: ["@lpa", "@smoke-journey"] }, () => {
   });
 
   it("should remove a warning", () => {
+    cy.waitForStableDOM();
     cy.contains(".warnings .opg-icon", "CreateWarning").trigger("mouseover");
     cy.contains(".warnings .opg-icon", "RemoveWarning").click();
 

--- a/cypress/e2e/lpa/cases/warnings.cy.js
+++ b/cypress/e2e/lpa/cases/warnings.cy.js
@@ -19,6 +19,7 @@ describe("Warnings", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
     cy.loginAs("LPA Manager");
     cy.visit(this.url);
+    cy.waitForStableDOM();
     cy.wait(["@warningsRequest"]);
     cy.get(".person-panel-details").contains(this.donorUid);
   });

--- a/cypress/e2e/lpa/donors/donor.cy.js
+++ b/cypress/e2e/lpa/donors/donor.cy.js
@@ -2,7 +2,6 @@ describe("Create Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
   beforeEach(() => {
     cy.loginAs("Case Manager");
     cy.visit("/lpa/home");
-    cy.waitForStableDOM();
   });
 
   it("should create a new donor", function () {
@@ -11,6 +10,7 @@ describe("Create Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
     );
     cy.wait("@tasksRequest");
 
+    cy.waitForStableDOM();
     cy.get("uib-tab-heading[id=Timeline]").contains("Timeline").click();
     cy.contains("Create Donor").click();
 
@@ -57,11 +57,12 @@ describe("Edits a Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should change the donor's firstname", function () {
     cy.visit(`/lpa/#/person/${this.donorId}`);
-    cy.waitForStableDOM();
+
     cy.intercept({ method: "GET", url: "/*/v1/persons/*" }).as("personRequest");
 
     cy.get(".person-panel-details").contains(this.donorUid);
 
+    cy.waitForStableDOM();
     cy.contains("Edit Donor").click();
     cy.frameLoaded(".action-widget-content iframe");
     cy.enter(".action-widget-content iframe").then((getBody) => {

--- a/cypress/e2e/lpa/donors/donor.cy.js
+++ b/cypress/e2e/lpa/donors/donor.cy.js
@@ -2,6 +2,7 @@ describe("Create Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
   beforeEach(() => {
     cy.loginAs("Case Manager");
     cy.visit("/lpa/home");
+    cy.waitForStableDOM();
   });
 
   it("should create a new donor", function () {
@@ -56,6 +57,7 @@ describe("Edits a Donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
 
   it("should change the donor's firstname", function () {
     cy.visit(`/lpa/#/person/${this.donorId}`);
+    cy.waitForStableDOM();
     cy.intercept({ method: "GET", url: "/*/v1/persons/*" }).as("personRequest");
 
     cy.get(".person-panel-details").contains(this.donorUid);

--- a/cypress/e2e/lpa/donors/link.cy.js
+++ b/cypress/e2e/lpa/donors/link.cy.js
@@ -20,11 +20,11 @@ describe("Link donors", { tags: ["@lpa", "@smoke-journey"] }, () => {
     );
 
     cy.visit(`/lpa/#/person/${this.primaryDonorId}`);
-    cy.waitForStableDOM();
 
     cy.wait("@donorRequest");
     cy.wait("@eventsRequest");
 
+    cy.waitForStableDOM();
     cy.contains("Workflow").click();
     cy.contains("Link Record").click();
 

--- a/cypress/e2e/lpa/donors/link.cy.js
+++ b/cypress/e2e/lpa/donors/link.cy.js
@@ -20,6 +20,7 @@ describe("Link donors", { tags: ["@lpa", "@smoke-journey"] }, () => {
     );
 
     cy.visit(`/lpa/#/person/${this.primaryDonorId}`);
+    cy.waitForStableDOM();
 
     cy.wait("@donorRequest");
     cy.wait("@eventsRequest");

--- a/cypress/support/lpa-commands.js
+++ b/cypress/support/lpa-commands.js
@@ -23,3 +23,32 @@ Cypress.Commands.add("createInvestigation", (lpaId) =>
 Cypress.Commands.add("putInvestigationOnHold", (investigationId) =>
   cy.postToApi(`/api/v1/investigations/${investigationId}/hold-periods`, {reason: "Police Investigation"}).its("body")
 );
+
+const waitForStableDOM = (iteration = 0) => {
+  let mutation,
+    pollInterval = 1000,
+    timeout = 60000;
+
+  const observer = new MutationObserver((m) => mutation = m);
+  observer.observe(document, {
+    subtree: true,
+    childList: true,
+    attributes: true,
+    attributeOldValue: true,
+    characterData: true,
+    characterDataOldValue: true,
+  });
+
+  cy.document().then(document => {
+    cy.wait(pollInterval).then(() => {
+      if (!mutation) {
+        return cy.wrap(document);
+      } else if (iteration * pollInterval < timeout) {
+        return waitForStableDOM(iteration + 1);
+      } else {
+        throw Error('Timed out waiting for stable DOM');
+      }
+    });
+  })
+}
+Cypress.Commands.add("waitForStableDOM", () => waitForStableDOM());


### PR DESCRIPTION
Attempts to address two problems:

1. Wait for the app to render fully before interacting with it

For example, when "Add Investigation" is clicked before the page has rendered fully, the app will error with the below and stop the iframe from loading. This affects most initial click events

```
TypeError: Cannot read properties of undefined (reading 'id')
    at new InvestigationCtrl (investigation.ctrl.js:171:72)
    at Object.instantiate (angular.js:5223:14)
    at $controller (angular.js:11829:28)
    at widgetCtrl.directive.js:14:21
    at Scope.$digest (angular.js:19269:34)
    at ChildScope.$apply (angular.js:19630:24)
    at HTMLAnchorElement.<anonymous> (angular.js:29127:19)
    at HTMLAnchorElement.dispatch (jquery.js:5494:27)
    at elemData.handle (jquery.js:5298:28)
```

2. `.contains` seems to be a bit slower than `.find`.  The problem is when a click event reloads an iframe before `.contains` finds whatever it was looking for within the frame. I've made those synchronous
