### PR TITLE
Allow `/auth/logout` to give 401

### DIFF
--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -2,7 +2,7 @@ require("cypress-iframe");
 require("cypress-wait-until");
 
 Cypress.Commands.add("login", (email) => {
-  cy.visit("/auth/logout");
+  cy.visit("/auth/logout", { failOnStatusCode: false });
   cy.clearCookies();
 
   cy.visit("/oauth/login");


### PR DESCRIPTION
When we force SSO login in non-dev environments, `/auth/logout` will redirect to a 401 page. This change ensures that the tests will still pass.

For VEGA-1719 #patch