### PR TITLE
VEGA-1799 re-enable remove warning test

### DIFF
--- a/cypress/e2e/lpa/cases/warnings.cy.js
+++ b/cypress/e2e/lpa/cases/warnings.cy.js
@@ -1,4 +1,4 @@
-describe("Warnings", { tags: ["@lpa", "@smoke-journey"] }, () => {
+describe("Warnings on a case", { tags: ["@lpa", "@smoke-journey"] }, () => {
   before(() => {
     cy.loginAs("LPA Manager");
     cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
@@ -16,7 +16,7 @@ describe("Warnings", { tags: ["@lpa", "@smoke-journey"] }, () => {
     cy.get(".person-panel-details").contains(this.donorUid);
   });
 
-  it("should create a warning", () => {
+  it("should create a warning on the case", () => {
     cy.contains("Create Warning").click();
 
     cy.waitForIframe(".action-widget-content iframe", { selector: "#f-warningType" });
@@ -36,9 +36,63 @@ describe("Warnings", { tags: ["@lpa", "@smoke-journey"] }, () => {
     );
   });
 
-  // it("should remove a warning", () => {
-  //   cy.contains("Remove warning").click();
-  //   cy.contains(".warnings", "No warnings in place");
-  //   cy.contains(".timeline-event", "Warning removed by atwo manager");
-  // });
+  it("should remove a warning on a case", () => {
+    cy.contains("Remove warning").click();
+    cy.get(".remove-warning-modal").contains("Fee Issue");
+    cy.get(".remove-warning-modal").contains("Applied to");
+    cy.get(".remove-warning-modal").contains("This is a big problem");
+    cy.get(".remove-warning-modal").contains("Remove warning").click();
+
+    cy.contains(".warnings", "No warnings in place");
+    cy.contains(".timeline-event", "Warning removed by atwo manager");
+  });
+});
+
+
+describe("Warnings on the donor", { tags: ["@lpa", "@smoke-journey"] }, () => {
+  before(() => {
+    cy.loginAs("LPA Manager");
+    cy.createDonor().then(({ id: donorId, uId: donorUid }) => {
+      cy.wrap(donorUid).as("donorUid");
+      cy.wrap(`/lpa/#/person/${donorId}`).as("url");
+    });
+  });
+
+  beforeEach(function () {
+    cy.loginAs("LPA Manager");
+    cy.visit(this.url);
+    cy.waitForStableDOM();
+    cy.get(".person-panel-details").contains(this.donorUid);
+  });
+
+  it("should create a warning on the donor record", () => {
+    cy.contains("Create Warning").click();
+
+    cy.waitForIframe(".action-widget-content iframe", { selector: "#f-warningType" });
+    cy.enter(".action-widget-content iframe").then((getBody) => {
+      getBody().find("#f-warningType").select("Fee Issue");
+      getBody().find("#f-warningText").type("This is a big problem");
+      getBody().find("button[type=submit]").click();
+    });
+
+    cy.contains(".warning-item", "Fee Issue").should(
+      "contain",
+      "This is a big problem"
+    );
+    cy.contains(".timeline-event", "Fee Issue").should(
+      "contain",
+      "This is a big problem"
+    );
+  });
+
+  it("should remove a warning on the donor record", () => {
+    cy.contains("Remove warning").click();
+    cy.get(".remove-warning-modal").contains("Fee Issue");
+    cy.get(".remove-warning-modal").contains("This is a big problem");
+    cy.contains(".remove-warning-modal", "Applied to:").should('not.exist');
+    cy.get(".remove-warning-modal").contains("Remove warning").click();
+
+    cy.contains(".warnings", "No warnings in place");
+    cy.contains(".timeline-event", "Warning removed by atwo manager");
+  });
 });


### PR DESCRIPTION
Added an extra test for creating & removing warnings on the donor record as well as on a case so that we cover scenarios for both pre-existing warnings and new warnings that will on case(s) going forward
