### PR TITLE
SW-5017 Updated create test to send string bools

### DIFF
--- a/cypress/fixtures/deputy-contact/minimal.json
+++ b/cypress/fixtures/deputy-contact/minimal.json
@@ -2,6 +2,6 @@
   "contactName": "Test Contact",
   "phoneNumber": "(0121) 071 5088",
   "email": "test@email.com",
-  "isMainContact": false,
-  "isNamedDeputy": false
+  "isMainContact": "false",
+  "isNamedDeputy": "false"
 }


### PR DESCRIPTION
Updated the create deputy contact test to send booleans in the form of strings (as Go sends them), instead of actual booleans. This doesn't affect the current test performance, but allows the manage deputy contact branch in sirius to pass e2e tests.