### PR TITLE
Update navigation link tests

### DIFF
--- a/cypress/support/navigation-commands.js
+++ b/cypress/support/navigation-commands.js
@@ -32,10 +32,15 @@ const navigationLinks = {
     url: '/supervision/workflow',
     position: 2,
   },
+  guidance: {
+    title: "Guidance",
+    url: 'https://wordpress.sirius.opg.service.justice.gov.uk',
+    position: 3,
+  },
   financeUrl: {
     title: "Finance",
     url: '/supervision/#/finance-hub/reporting',
-    position: 3,
+    position: 4,
   }
 }
 


### PR DESCRIPTION
ministryofjustice/opg-sirius-header#26 inserted a new navigation link, so this needs to be included in the tests

For SW-6660 #patch 