### PR TITLE
SW-6749 Updated extend visit test to use tomorrow's date

### DIFF
--- a/cypress/e2e/supervision/clients/visits/extend-visit.cy.js
+++ b/cypress/e2e/supervision/clients/visits/extend-visit.cy.js
@@ -1,6 +1,11 @@
 let today = new Date();
 today.setDate(today.getDate() + 1);
-const tomorrowsDate = today.toLocaleDateString();
+
+const tomorrowsDate = today.toLocaleDateString(undefined, {
+  year: 'numeric',
+  month: '2-digit',
+  day: '2-digit'
+});
 
 beforeEach(() => {
   cy.loginAs("Case Manager");

--- a/cypress/e2e/supervision/clients/visits/extend-visit.cy.js
+++ b/cypress/e2e/supervision/clients/visits/extend-visit.cy.js
@@ -1,3 +1,7 @@
+let today = new Date();
+today.setDate(today.getDate() + 1);
+const tomorrowsDate = today.toLocaleDateString();
+
 beforeEach(() => {
   cy.loginAs("Case Manager");
   cy.createClient();
@@ -7,7 +11,7 @@ beforeEach(() => {
   cy.get("@visitId").then((visitId) => {
     cy.get("@client").then(({id}) => {
       let data = {
-        "visitReportDueDate": "22/03/2023",
+        "visitReportDueDate": tomorrowsDate,
         "whoToVisit": {
           "handle": "VPT-CLIENT",
           "label": "Client"
@@ -30,11 +34,11 @@ describe(
         cy.get(".visit-type-field").contains("Supervision");
         cy.get(".visit-sub-type-field").contains("Pro Visit");
         cy.get(".visit-urgency-field").contains("Standard");
-        cy.get(".visit-report-due-date-field").contains("22/03/2023");
+        cy.get(".visit-report-due-date-field").contains(tomorrowsDate);
         cy.get("visit-list-item-view").then(() => {
           cy.contains("Who to visit: Client")
           cy.contains("Supervision - Pro Visit - Standard");
-          cy.contains("Visit report due by: 22/03/2023")
+          cy.contains("Visit report due by: " + tomorrowsDate)
         });
         cy.get(".extend-visit-report-due-date-button").click();
 


### PR DESCRIPTION
Updated extend visit test to use tomorrow's date as the report due date. This currently doesn't affect any tests, but is needed for ticket SW-6749 to pass tests, as it requires this date to always be in the future when first set.