### PR TITLE
SW-6749 Specified locale to fix date behaviour in pipeline

### DIFF
--- a/cypress/e2e/supervision/clients/visits/extend-visit.cy.js
+++ b/cypress/e2e/supervision/clients/visits/extend-visit.cy.js
@@ -1,7 +1,7 @@
 let today = new Date();
 today.setDate(today.getDate() + 1);
 
-const tomorrowsDate = today.toLocaleDateString(undefined, {
+const tomorrowsDate = today.toLocaleDateString('en-GB', {
   year: 'numeric',
   month: '2-digit',
   day: '2-digit'


### PR DESCRIPTION
Specified to use the English date format when getting tomorrow's date, as currently this uses the American format. This doens't affect any current tests, but is required for the sirius PR for this ticket