### PR TITLE
Increase timeouts

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -4,6 +4,8 @@ const fs = require("fs");
 
 module.exports = defineConfig({
   defaultCommandTimeout: 60000,
+  requestTimeout: 60000,
+  responseTimeout: 60000,
   reporter: "cypress-multi-reporters",
   chromeWebSecurity: false,
   modifyObstructiveCode: false,

--- a/cypress/e2e/supervision/clients/edit-client.cy.js
+++ b/cypress/e2e/supervision/clients/edit-client.cy.js
@@ -9,7 +9,7 @@ const editClient = (isCourtReferenceChanged) => {
       method: "PUT",
       url: `/supervision-api/v1/clients/${id}`,
     }).as("editClientCall");
-    cy.get('input[name="firstName"]', { timeout: 2000 }).should('be.visible');
+    cy.get('input[name="firstName"]').should('be.visible');
     cy.get('input[name="firstName"]').should("have.value", firstname);
     cy.get('input[name="firstName"]').should("not.be.disabled");
     cy.get('input[name="firstName"]').clear();

--- a/cypress/support/forms.js
+++ b/cypress/support/forms.js
@@ -2,7 +2,7 @@ Cypress.Commands.add("waitForTinyMCE", () => {
   cy.window()
     .its("tinyMCE")
     .its("activeEditor")
-    .its("initialized", {timeout: 2000});
+    .its("initialized", {timeout: 60000});
   return cy.window().then((win) => {
     let editor = win.tinymce.activeEditor;
     editor.dom.createRng();


### PR DESCRIPTION
- Increase default timeout for requests in a wait() to go out from 5s to 60s
- Increase default timeout for responses in a wait() (and some other calls) to go out from 30s to 60s
- Increase timeout for Tiny MCE to initialise from 2s to 60s
- Remove 2s timeout on waiting for firstname field in Edit Client test