### PR TITLE
Force clicking the order type radio button

### DIFF
--- a/cypress/e2e/supervision/orders/create-order.cy.js
+++ b/cypress/e2e/supervision/orders/create-order.cy.js
@@ -11,7 +11,7 @@ const createOrder = (orderType, orderSubType, orderDate, optional) => {
     cy.get("#orderType")
       .closest(".fieldset")
       .contains(orderType)
-      .click();
+      .click({ force: true });
     cy.contains("Order subtype")
       .closest(".fieldset")
       .find("Select")


### PR DESCRIPTION
We regularly get fails here because "this element is currently animating". Looking at the failure screenshot this may be to do with scrolling.

`{waitForAnimations: false}` disables the "is animating" check, which doesn't feel like a pretty solution but may at least reduce test flakes.

#patch

## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
