### PR TITLE
Upgrade cypress to 13.6.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1273,9 +1273,9 @@
       "integrity": "sha512-Cr4U38xg5z8AK8XiYuEcbAy1rfgtkZTdUFTWkG5NM+BxKSjRlpGt6LpylLpHp9B6ikKCBPotpeewW7fOuBFKlA=="
     },
     "node_modules/cypress": {
-      "version": "13.4.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.4.0.tgz",
-      "integrity": "sha512-KeWNC9xSHG/ewZURVbaQsBQg2mOKw4XhjJZFKjWbEjgZCdxpPXLpJnfq5Jns1Gvnjp6AlnIfpZfWFlDgVKXdWQ==",
+      "version": "13.6.1",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-13.6.1.tgz",
+      "integrity": "sha512-k1Wl5PQcA/4UoTffYKKaxA0FJKwg8yenYNYRzLt11CUR0Kln+h7Udne6mdU1cUIdXBDTVZWtmiUjzqGs7/pEpw==",
       "hasInstallScript": true,
       "dependencies": {
         "@cypress/request": "^3.0.0",


### PR DESCRIPTION
## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
