### PR TITLE
sw-6896: Moves bond button workaround to waits as the orders loading …

### DIFF
--- a/cypress/e2e/supervision/deputies/add-deputy.cy.js
+++ b/cypress/e2e/supervision/deputies/add-deputy.cy.js
@@ -38,13 +38,10 @@ describe(
       cy.get(".footer > .dotted-link").should("contain.text", "Exit").click();
 
       cy.get(".TABS_DEPUTIES").click();
-      cy.waitForLoading("Loading deputies...");
+
+      cy.get("#deputies-table").find("tr.summary-row").should("have.length", 1);
 
       cy.get("#deputies-table").within(() => {
-        cy.find("tr")
-          .then((rows) => {
-            expect(rows.length === 1);
-          });
         cy.get(".deputy-name").contains(fullName).should("be.visible");
         cy.get(".deputy-type").contains("Lay");
         cy.get(".deputy-status-on-case").contains("Open");
@@ -88,13 +85,10 @@ describe(
         cy.get(".deputy-search__use-button").first().click();
 
         cy.get(".TABS_DEPUTIES").click();
-        cy.waitForLoading("Loading deputies...");
+
+        cy.get("#deputies-table").find("tr.summary-row").should("have.length", 1);
 
         cy.get("#deputies-table").within(() => {
-          cy.find("tr")
-            .then((rows) => {
-              expect(rows.length === 1);
-            });
           cy.get(".deputy-name").contains(fullName).should("be.visible");
           cy.get(".deputy-type").contains("Professional");
           cy.get(".deputy-status-on-case").contains("Open");
@@ -145,13 +139,9 @@ describe(
         cy.get(".deputy-search__use-button").first().click();
 
         cy.get(".TABS_DEPUTIES").click();
-        cy.waitForLoading("Loading deputies...");
 
-        cy.get("#deputies-table")
-          .find("tr")
-          .then((rows) => {
-            expect(rows.length === 1);
-          });
+        cy.get("#deputies-table").find("tr.summary-row").should("have.length", 1);
+
         cy.get("#add-deputy-button").should("be.visible").click();
         cy.get(".deputy-search__input")
           .should("be.visible")
@@ -163,7 +153,7 @@ describe(
       });
     });
 
-    it.only(
+    it(
       "Sets the deputy as the main fee payer and correspondent when added to a client",
       {
         retries: {
@@ -183,7 +173,6 @@ describe(
         cy.get(".footer > .dotted-link").should("contain.text", "Exit").click();
 
         cy.get(".TABS_DEPUTIES").click();
-        cy.waitForLoading("Loading deputies...");
 
         cy.get("#deputies-table").within(() => {
           cy.contains("View full details").click();

--- a/cypress/e2e/supervision/orders/bonds/add-bond.cy.js
+++ b/cypress/e2e/supervision/orders/bonds/add-bond.cy.js
@@ -15,9 +15,8 @@ describe(
       });
 
       cy.get(".TABS_ORDERS").click();
-      cy.get("#tab-order-list-in-page-notification").should("contain", "Please wait...");
-      cy.get("#tab-order-list-in-page-notification").should("not.contain", "Please wait...");
       cy.get('.add-bond-button').click();
+
       cy.get('#securityBond').contains('Yes').click()
 
       cy.get('#requiredBondAmount').type("1000");

--- a/cypress/e2e/supervision/orders/bonds/dispense-bond.cy.js
+++ b/cypress/e2e/supervision/orders/bonds/dispense-bond.cy.js
@@ -22,11 +22,6 @@ describe(
 
       cy.get(".TABS_ORDERS").click();
 
-      // action buttons for orders are not actually clickable until the orders are fully loaded so
-      // we need to wait for the notification to disappear
-      cy.get("#tab-order-list-in-page-notification").should("contain", "Please wait...");
-      cy.get("#tab-order-list-in-page-notification").should("not.contain", "Please wait...");
-
       cy.get(".edit-bond-button").click();
       cy.contains("button", "Dispense with the bond").click();
 

--- a/cypress/e2e/supervision/orders/bonds/edit-bond.cy.js
+++ b/cypress/e2e/supervision/orders/bonds/edit-bond.cy.js
@@ -23,8 +23,6 @@ describe(
       });
 
       cy.get(".TABS_ORDERS").click();
-      cy.get("#tab-order-list-in-page-notification").should("contain", "Please wait...");
-      cy.get("#tab-order-list-in-page-notification").should("not.contain", "Please wait...");
       cy.get(".edit-bond-button").click();
 
       cy.get('#requiredBondAmount').clear();


### PR DESCRIPTION
…header is no longer present

## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
