### PR TITLE
sw-6896: Removes banner checks for bond button readiness

### DIFF
--- a/cypress/e2e/supervision/orders/bonds/dispense-bond.cy.js
+++ b/cypress/e2e/supervision/orders/bonds/dispense-bond.cy.js
@@ -22,11 +22,6 @@ describe(
 
       cy.get(".TABS_ORDERS").click();
 
-      // action buttons for orders are not actually clickable until the orders are fully loaded so
-      // we need to wait for the notification to disappear
-      cy.get("#tab-order-list-in-page-notification").should("contain", "Please wait...");
-      cy.get("#tab-order-list-in-page-notification").should("not.contain", "Please wait...");
-
       cy.get(".edit-bond-button").click();
       cy.contains("button", "Dispense with the bond").click();
 


### PR DESCRIPTION
## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
