### PR TITLE
SW-7051 Updated selectors to use content & run tests with Chromium

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,10 +41,8 @@ RUN apt-get update && apt-get install -y \
 	curl \
 	gnupg \
 	--no-install-recommends \
-	&& curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-	&& echo "deb https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
 	&& apt-get update && apt-get install -y \
-	google-chrome-stable \
+	chromium \
 	fontconfig \
 	fonts-ipafont-gothic \
 	fonts-wqy-zenhei \
@@ -67,11 +65,12 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 #RUN apt-get install mplayer -y
 
 # install Firefox browser
-ARG FIREFOX_VERSION=93.0
-RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && ln -fs /opt/firefox/firefox /usr/bin/firefox
+# As above, we don't use video so can just use chromium
+#ARG FIREFOX_VERSION=93.0
+#RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+#  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+#  && rm /tmp/firefox.tar.bz2 \
+#  && ln -fs /opt/firefox/firefox /usr/bin/firefox
 
 # avoid too many progress messages
 # https://github.com/cypress-io/cypress/issues/1243

--- a/cypress/e2e/supervision/contacts/edit-contact.cy.js
+++ b/cypress/e2e/supervision/contacts/edit-contact.cy.js
@@ -15,7 +15,7 @@ describe(
   {tags: ["@supervision-core", "@contact", "@smoke-journey"]},
   () => {
     it("can edit a non organisation contact", () => {
-      cy.get(".contacts-list").contains("a", "Edit").click();
+      cy.get(".contacts-list").contains("Edit").click();
       cy.get("footer").contains("button", "Save & update contact").as("editContactButton");
 
       cy.get("input[name=firstName]").type("A".repeat(256));

--- a/cypress/e2e/supervision/deputies/unlink-deputy.cy.js
+++ b/cypress/e2e/supervision/deputies/unlink-deputy.cy.js
@@ -34,7 +34,7 @@ describe(
         cy.intercept({ method: "DELETE" }).as("unlinkDeputyCall");
         cy.get("tr.summary-row")
           .filter(':contains("' + salutation + ' ' + firstname + ' ' + surname + '")')
-          .find("a.unlink-deputy").click()
+          .contains("Un-link deputy").click()
         cy.get("unlink-deputy-dialog").contains("Unlink deputy").click()
         cy.wait("@unlinkDeputyCall").then(() => {
           cy.reload()

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "doc": "docs"
   },
   "scripts": {
-    "test": "cypress run --headless --browser chrome",
+    "test": "cypress run --headless --browser chromium",
     "parallel": "cypress-parallel --reporter cypress-multi-reporters --reporterOptions configFile=reporter-config.json -s test -t ${PARALLELISATION:=3} -d cypress/e2e"
   },
   "repository": {


### PR DESCRIPTION
Update Dockerfile to install Chromium and use it to run tests rather than Chrome, so these can be ran on ARM Macbooks (as there's no google-chrome-stable for ARM). 
Also update some selectors to use content rather than element, for this PR 
https://github.com/ministryofjustice/opg-sirius/pull/10101

## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
