### PR TITLE
sw-7292 stripping out newsletter test fix

### DIFF
--- a/cypress/e2e/supervision/deputies/add-deputy.cy.js
+++ b/cypress/e2e/supervision/deputies/add-deputy.cy.js
@@ -53,7 +53,6 @@ describe(
           cy.get(".deputy-details-type").contains("Lay");
           cy.get(".deputy-details-deputy-name").contains(fullName);
           cy.get(".deputy-details-is-airmail-required").contains("No");
-          cy.get(".deputy-additional-details-newsletter").contains("No");
           cy.get(".order-details-deputy-type").contains("Lay");
           cy.get(".order-details-main-correspondent").contains("Yes");
           cy.get(".order-details-deputy-status-on-case").contains("Open");
@@ -99,7 +98,6 @@ describe(
             cy.get(".deputy-details-type").contains("Professional");
             cy.get(".deputy-details-deputy-name").contains(fullName);
             cy.get(".deputy-details-is-airmail-required").contains("No");
-            cy.get(".deputy-additional-details-newsletter").contains("No");
             cy.get(".order-details-deputy-type").contains("Professional");
             cy.get(".order-details-main-correspondent").contains("Yes");
             cy.get(".order-details-deputy-status-on-case").contains("Open");


### PR DESCRIPTION
## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
