### PR TITLE
Wait for document to appear on timeline before opening it

### DIFF
--- a/cypress/e2e/lpa/cases/documents.cy.js
+++ b/cypress/e2e/lpa/cases/documents.cy.js
@@ -69,8 +69,9 @@ describe("Documents", { tags: ["@lpa", "@smoke-journey"] }, () => {
     });
 
     cy.waitForStableDOM();
+    cy.contains(".timeline-event", "Outbound document");
     cy.get('button[title="Documents associated to this case"]').click();
-    cy.get(".document-list").contains("IT-BANK-LPA").click();
+    cy.get(".document-list").contains("IT-BANK-LPA",).click();
 
     cy.waitForIframe("#docViewer");
     cy.enter("iframe#docViewer").then((getBody) => {


### PR DESCRIPTION
This ensures it will be available in the document list, rather than risking a race condition.

For VEGA-2769 #patch

## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
