### PR TITLE
Tighten npm install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -92,7 +92,7 @@ COPY --chown=node:node package-lock.json package-lock.json
 
 USER node
 
-RUN npm install
+RUN npm ci --ignore-scripts
 
 ENV CYPRESS_VIDEO=false
 


### PR DESCRIPTION
use npm ci --ignore-scripts when installing packages

#patch

## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
