### PR TITLE
sfs-423: Updates client commands to use the id and caserecnumber only…

### DIFF
--- a/cypress/support/client-commands.js
+++ b/cypress/support/client-commands.js
@@ -1,17 +1,18 @@
 import randomText from "./random-text";
 
 Cypress.Commands.add("createClient", (overrides = {}, alias = "client") => {
+  let data;
   cy.fixture("client/minimal.json").then((client) => {
-    client = {
+    data = {
       ...client,
       firstname: randomText(),
       surname: randomText(),
       ...overrides
     };
-    cy.postToApi("/api/v1/clients", client)
+    cy.postToApi("/api/v1/clients", data)
       .its("body")
       .then((res) => {
-        cy.wrap(res).as(alias);
+        cy.wrap({ ...data, ...res }).as(alias);
       });
   });
 });


### PR DESCRIPTION
… from the response in the aliased client, with other data coming from the fixture. This is so the client API can be updated to return only the data needed in production and not be coupled with test requirements

## If you have updated any tests...

1. Run Cypress_End_to_End_Tests on Jenkins against this PRs tag
2. Update parallel-weights.json with the values found in the artifacts of that run

* [ ] I have updated parallel-weights.json
