### PR TITLE
Switch browser to electron

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,7 +40,6 @@ RUN apt-get update && apt-get install -y \
 	gnupg \
 	--no-install-recommends \
 	&& apt-get update && apt-get install -y \
-	chromium \
   wget \
 	fontconfig \
 	fonts-ipafont-gothic \
@@ -62,13 +61,6 @@ ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 # https://github.com/cypress-io/cypress-docker-images/issues/150
 # We don't use video so disabling until we need it
 #RUN apt-get install mplayer -y
-
-# install Firefox browser
-ARG FIREFOX_VERSION=93.0
-RUN wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && ln -fs /opt/firefox/firefox /usr/bin/firefox
 
 # avoid too many progress messages
 # https://github.com/cypress-io/cypress/issues/1243

--- a/package.json
+++ b/package.json
@@ -8,8 +8,8 @@
   },
   "scripts": {
     "lint": "eslint . --ignore-pattern \"**/*.js\"",
-    "test": "cypress run --headless --browser chromium",
-    "test-single": "cypress run --headless --browser chromium --spec \"cypress/e2e/common/login.cy.js\"",
+    "test": "cypress run --headless --browser electron",
+    "test-single": "cypress run --headless --browser electron --spec \"cypress/e2e/common/login.cy.js\"",
     "ui": "cypress open -c baseUrl=http://localhost:8080",
     "ui:dev": "cypress open -c baseUrl=https://development.sirius.opg.service.justice.gov.uk",
     "parallel": "cypress-parallel --reporter cypress-multi-reporters --reporterOptions configFile=reporter-config.json -s test -t ${PARALLELISATION:=3} -d cypress/e2e"


### PR DESCRIPTION
Chrome does not ship a version compatible with Linux arm64 architecture, so switch to using Electron which is at least consistently available on all architecture.

#minor